### PR TITLE
use non-portable docker entrypoints

### DIFF
--- a/cwl_adapters/basic-flatfield-estimation.cwl
+++ b/cwl_adapters/basic-flatfield-estimation.cwl
@@ -18,10 +18,6 @@ requirements:
       writable: true  # Output directories must be writable
   InlineJavascriptRequirement: {}
 
-# See https://github.com/PolusAI/workflow-inference-compiler/blob/master/docker_remove_entrypoints.py
-baseCommand: python3
-arguments: ["-m", "polus.plugins.regression.basic_flatfield_estimation"]
-
 # "jax._src.xla_bridge - WARNING  - An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu."
 hints:
   cwltool:CUDARequirement:

--- a/cwl_adapters/bbbcdownload.cwl
+++ b/cwl_adapters/bbbcdownload.cwl
@@ -7,10 +7,6 @@ doc: |-
   Downloads the datasets on the Broad Bioimage Benchmark Collection website
   https://github.com/saketprem/polus-plugins/tree/bbbc_download/utils/bbbc-download-plugin
 
-# See https://github.com/PolusAI/workflow-inference-compiler/blob/master/docker_remove_entrypoints.py
-baseCommand: python3
-arguments: ["-m", "polus.plugins.utils.bbbc_download"]
-
 requirements:
   DockerRequirement:
     dockerPull: polusai/bbbc-download-plugin:0.1.0-dev1

--- a/cwl_adapters/file-renaming.cwl
+++ b/cwl_adapters/file-renaming.cwl
@@ -7,10 +7,6 @@ doc: |-
   Rename and store image collection files in a new image collection
   https://github.com/PolusAI/polus-plugins/tree/master/formats/file-renaming-plugin
 
-# See https://github.com/PolusAI/workflow-inference-compiler/blob/master/docker_remove_entrypoints.py
-baseCommand: python3
-arguments: ["-m", "polus.plugins.formats.file_renaming"]
-
 requirements:
   DockerRequirement:
     dockerPull: polusai/file-renaming-plugin:0.2.1-dev0  # NOTE: 0.2.3 not pushed yet

--- a/cwl_adapters/image_assembler.cwl
+++ b/cwl_adapters/image_assembler.cwl
@@ -8,10 +8,6 @@ doc: |-
   This plugin assembles images into a stitched image using an image stitching vector.
   https://github.com/PolusAI/polus-plugins/tree/master/transforms/images/image-assembler-plugin
 
-# See https://github.com/PolusAI/workflow-inference-compiler/blob/master/docker_remove_entrypoints.py
-baseCommand: python3
-arguments: ["-m", "polus.plugins.transforms.images.image_assembler"]
-
 requirements:
   DockerRequirement:
     dockerPull: polusai/image-assembler-plugin:1.4.0-dev0

--- a/cwl_adapters/montage.cwl
+++ b/cwl_adapters/montage.cwl
@@ -8,10 +8,6 @@ doc: |-
   This plugin generates a stitching vector that will montage images together.
   https://github.com/PolusAI/polus-plugins/tree/master/transforms/images/montage-plugin
 
-# See https://github.com/PolusAI/workflow-inference-compiler/blob/master/docker_remove_entrypoints.py
-baseCommand: python3
-arguments: ["-m", "polus.plugins.transforms.images.montage"]
-
 requirements:
   DockerRequirement:
     dockerPull: polusai/montage-plugin:0.5.0

--- a/cwl_adapters/ome-converter.cwl
+++ b/cwl_adapters/ome-converter.cwl
@@ -8,10 +8,6 @@ doc: |-
   This WIPP plugin converts BioFormats supported data types to the OME Zarr file format.
   https://github.com/PolusAI/polus-plugins/tree/master/formats/ome-converter-plugin
 
-# See https://github.com/PolusAI/workflow-inference-compiler/blob/master/docker_remove_entrypoints.py
-baseCommand: python3
-arguments: ["-m", "polus.plugins.formats.ome_converter"]
-
 requirements:
   DockerRequirement:
     dockerPull: jakefennick/ome-converter-plugin:0.3.2

--- a/cwl_adapters/precompute_slide.cwl
+++ b/cwl_adapters/precompute_slide.cwl
@@ -8,10 +8,6 @@ doc: |-
   This plugin generates image pyramids in multiple viewing formats.
   https://github.com/PolusAI/polus-plugins/tree/master/visualization/polus-precompute-slide-plugin
 
-# See https://github.com/PolusAI/workflow-inference-compiler/blob/master/docker_remove_entrypoints.py
-baseCommand: python3
-arguments: ["-m", "polus.plugins.visualization.precompute_slide"]
-
 requirements:
   DockerRequirement:
     dockerPull: polusai/precompute-slide-plugin:1.7.0-dev0


### PR DESCRIPTION
See https://github.com/PolusAI/workflow-inference-compiler/blob/master/docker_remove_entrypoints.py

```
# https://cwl.discourse.group/t/override-docker-entrypoint-in-command-line-tool/695/2
# "Here is what the CWL standards have to say about software container entrypoints"
# "I recommend changing your docker container to not use ENTRYPOINT."

# This script will remove / overwrite the entrypoints in ALL of the docker images on your local machine.
# (It will append -noentrypoint to the version tag.)

# The reason is that we want to simultaneously allow
# 1. release environments, where users will simply run code in a docker image and
# 2. dev/test environments, where developers can run the latest code on the host machine and/or in the CI.

# With entrypoints, there is no easy way to switch between 1 and 2; developers will
# have to manually prepend the entrypoint string to the baseCommand, and/or possibly
# modify paths to be w.r.t. their host machine instead of w.r.t. the image. (/opt/.../main.py)

# Without entrypoints, to switch between 1 and 2, simply comment out DockerRequirement ... that's it!
# The point is that we want a uniform API so that we can programmatically switch between 1 and 2 in the CI.
# We want to run the integration tests first, and only push releases to dockerhub when the tests pass (NOT vice versa!).
```

Since the above arguments have clearly either not been understood or not appreciated, let's just nuke it and move on.