### PR TITLE
revert to upstream dev container

### DIFF
--- a/cwl_adapters/ome-converter.cwl
+++ b/cwl_adapters/ome-converter.cwl
@@ -10,7 +10,7 @@ doc: |-
 
 requirements:
   DockerRequirement:
-    dockerPull: jakefennick/ome-converter-plugin:0.3.2
+    dockerPull: polusai/ome-converter-plugin:0.3.2-dev2
   # See https://www.commonwl.org/v1.0/CommandLineTool.html#InitialWorkDirRequirement
   InitialWorkDirRequirement:
     listing:


### PR DESCRIPTION
This PR essentially reverts this commit https://github.com/polusai/image-workflows/commit/46cceeeca04fa9d77124c6d4aa0d2218b090024d 
However, since https://github.com/PolusAI/image-tools/pull/517 has not been merged yet, this PR also appends -dev2